### PR TITLE
Update commit and branch guideline

### DIFF
--- a/BRANCH_GUIDELINE.md
+++ b/BRANCH_GUIDELINE.md
@@ -1,8 +1,14 @@
 # Branch Guideline
 
-Branch names must only consist of `[a-z|A-Z|0-9|-|/]` characters and be in the form `<type>/<subject>`.
+Branch names must only consist of `[a-z|A-Z|0-9|-|/]` characters and are generally in the form `<type>/<subject>`.
 
 - `<type>` : One of the defined [Commit Types](/COMMIT_MESSAGE_GUIDELINE.md#type) we use.
 - `<subject>` : Starts with an imperative verb. Explains the goal of this branch.
 
 An example of a viable branch name is `feat/add-xyz`.
+
+## Exception for docs-only or small-purpose repositories
+
+In repositories that only contain documentation (e.g., `.github`) or small-purpose projects
+(e.g., benchmarks, experiments), the `type` prefix in branch names **may be omitted**.
+In such cases, use a clear and concise subject that still follows the rules above.

--- a/COMMIT_MESSAGE_GUIDELINE.md
+++ b/COMMIT_MESSAGE_GUIDELINE.md
@@ -40,6 +40,12 @@ The `footer` is optional. The [Commit Message Footer](#commit-footer) format des
 
 The `<type>` and `<summary>` fields are mandatory, the `(<scope>)` field is optional.
 
+### Exception for docs-only or small-purpose repositories
+
+In repositories that only contain documentation (e.g., `.github`) or small-purpose projects (e.g., benchmarks, experiments),
+`type` and `scope` may be omitted. In such cases, focus on writing a clear and concise summary that adheres to the guidelines
+in the "Summary" section.
+
 ### BREAKING CHANGE
 
 A commit that either:

--- a/COMMIT_MESSAGE_GUIDELINE.md
+++ b/COMMIT_MESSAGE_GUIDELINE.md
@@ -60,18 +60,18 @@ A BREAKING CHANGE can be part of commits of any type.
 
 Must be one of the following:
 
-| Type         | Description                                                                                                                                                              |
-| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **build**    | Changes that affect the build system or external dependencies                                                                                                            |
-| **chore**    | Minor housekeeping tasks that do not affect production logic. Examples: typo fixes, updating `.gitignore`, modifying `.env.example`, or adjusting linter/config settings |
-| **ci**       | Changes to our CI configuration files and scripts (examples: Github Actions, SauceLabs)                                                                                  |
-| **docs**     | Documentation only changes                                                                                                                                               |
-| **feat**     | A new feature                                                                                                                                                            |
-| **fix**      | A bug fix                                                                                                                                                                |
-| **perf**     | A code change that improves performance                                                                                                                                  |
-| **refactor** | A code change that neither fixes a bug nor adds a feature                                                                                                                |
-| **style**    | Code formatting changes that do **not affect behavior or logic**. Examples: white-space adjustments, indentation, semicolon fixes, sorting imports/build targets         |
-| **test**     | Adding missing tests or correcting existing tests                                                                                                                        |
+| Type         | Description                                                                                                                                                                                                                         |
+| ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **build**    | Changes that affect the build system or external dependencies                                                                                                                                                                       |
+| **chore**    | Minor housekeeping tasks that do not affect production logic. Examples: typo fixes, updating `.gitignore`, modifying `.env.example`, or adjusting linter/config settings                                                            |
+| **ci**       | Changes to our CI configuration files and scripts (examples: Github Actions, SauceLabs)                                                                                                                                             |
+| **docs**     | Documentation only changes                                                                                                                                                                                                          |
+| **feat**     | A new feature                                                                                                                                                                                                                       |
+| **fix**      | A bug fix. If the bug is non-trivial (e.g., not just a typo or obvious mistake), clearly explain the incorrect behavior and its cause in the commit body to ensure future readers can understand the context and impact of the fix. |
+| **perf**     | A code change that improves performance                                                                                                                                                                                             |
+| **refactor** | A code change that neither fixes a bug nor adds a feature                                                                                                                                                                           |
+| **style**    | Code formatting changes that do **not affect behavior or logic**. Examples: white-space adjustments, indentation, semicolon fixes, sorting imports/build targets                                                                    |
+| **test**     | Adding missing tests or correcting existing tests                                                                                                                                                                                   |
 
 ### <a name="scope"></a> Scope
 


### PR DESCRIPTION
## Description

This PR updates both **commit message** and **branch naming** guidelines to improve clarity and adaptability across different repositories.

### Changes

1. **Fix commit rule**

   * For commits of type `fix`, if the reason why this is a bug is **not trivial**, the commit body must explicitly explain **why** it is considered a bug.
   * This ensures better context for future readers and maintainers.

2. **Commit type/scope exception**

   * In docs-only repositories (e.g., `.github`) or small-purpose projects (e.g., benchmarks, experiments), `type` and `scope` in commit messages **may be omitted**.
   * Contributors should focus on writing a clear and concise summary instead.

3. **Branch naming exception**

   * Similarly, in docs-only or small-purpose repositories, the `type` prefix in branch names can be omitted.
   * Example: `update-guideline`, `benchmark-ntt-ops`.

### Motivation

* To reduce unnecessary overhead in small or documentation-only repositories.
* To enforce better documentation of non-trivial bug fixes.
* To make guidelines consistent between commit messages and branch names.

### Examples

* Commit:

  ```
  fix: correct MSM accumulation logic

  The bug was caused by missing carry propagation in edge cases. 
  This was not trivial because it only appeared with specific large inputs.
  ```
* Branch:

  ```
  update-guideline
  ```

## Related Issues/PRs

N/A

## Checklist

- [x] Branch name follows [Branch Guideline](https://github.com/zk-rabbit/.github/blob/main/BRANCH_GUIDELINE.md)
- [x] Commit messages follow [Commit Message Guideline](https://github.com/zk-rabbit/.github/blob/main/COMMIT_MESSAGE_GUIDELINE.md)
- [x] Checked [Pull Request Guideline](https://github.com/zk-rabbit/.github/blob/main/PULL_REQUEST_GUIDELINE.md)
